### PR TITLE
Allow casting from String -> Double when checking timestamps

### DIFF
--- a/JWT/Claims.swift
+++ b/JWT/Claims.swift
@@ -40,7 +40,7 @@ func validateIssuer(payload:Payload, issuer:String?) -> InvalidToken? {
 }
 
 func validateDate(payload:Payload, key:String, comparison:NSComparisonResult, failure:InvalidToken, decodeError:String) -> InvalidToken? {
-  if let timestamp = payload[key] as? NSTimeInterval {
+  if let timestamp = payload[key] as? NSTimeInterval ?? payload[key]?.doubleValue as NSTimeInterval? {
     let date = NSDate(timeIntervalSince1970: timestamp)
     if date.compare(NSDate()) == comparison {
       return failure

--- a/JWTTests/JWTTests.swift
+++ b/JWTTests/JWTTests.swift
@@ -131,6 +131,14 @@ class JWTDecodeTests : XCTestCase {
       XCTAssertEqual(payload as NSDictionary, ["exp": 1728188491])
     }
   }
+  
+  func testUnexpiredClaimString() {
+    // If this just started failing, hello 2024!
+    let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxNzI4MTg4NDkxIn0.y4w7lNLrfRRPzuNUfM-ZvPkoOtrTU_d8ZVYasLdZGpk"
+    assertSuccess(try decode(jwt, algorithm: .HS256("secret"))) { payload in
+      XCTAssertEqual(payload as NSDictionary, ["exp": "1728188491"])
+    }
+  }
 
   // MARK: Not before claim
 
@@ -138,6 +146,13 @@ class JWTDecodeTests : XCTestCase {
     let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0MjgxODk3MjB9.jFT0nXAJvEwyG6R7CMJlzNJb7FtZGv30QRZpYam5cvs"
     assertSuccess(try decode(jwt, algorithm: .HS256("secret"))) { payload in
       XCTAssertEqual(payload as NSDictionary, ["nbf": 1428189720])
+    }
+  }
+  
+  func testNotBeforeClaimString() {
+    let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOiIxNDI4MTg5NzIwIn0.qZsj36irdmIAeXv6YazWDSFbpuxHtEh4Deof5YTpnVI"
+    assertSuccess(try decode(jwt, algorithm: .HS256("secret"))) { payload in
+      XCTAssertEqual(payload as NSDictionary, ["nbf": "1428189720"])
     }
   }
 
@@ -158,6 +173,13 @@ class JWTDecodeTests : XCTestCase {
     let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0MjgxODk3MjB9.I_5qjRcCUZVQdABLwG82CSuu2relSdIyJOyvXWUAJh4"
     assertSuccess(try decode(jwt, algorithm: .HS256("secret"))) { payload in
       XCTAssertEqual(payload as NSDictionary, ["iat": 1428189720])
+    }
+  }
+  
+  func testIssuedAtClaimInThePastString() {
+    let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOiIxNDI4MTg5NzIwIn0.M8veWtsY52oBwi7LRKzvNnzhjK0QBS8Su1r0atlns2k"
+    assertSuccess(try decode(jwt, algorithm: .HS256("secret"))) { payload in
+      XCTAssertEqual(payload as NSDictionary, ["iat": "1428189720"])
     }
   }
 


### PR DESCRIPTION
Not all server-side JWT packages drop the quotes around returned values. If a timestamp is returned with quotes a decoding error will occur because `as? NSTimeInterval` will fail on strings. This will also attempt to parse strings to a double value and use that as the timestamp.

(Ideally this would be a change for the JSON parser, but that isn't something we can control)