### PR TITLE
Swift 2.2 / Xcode 7.3 / Updated CryptoSwift dependency to 0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 script:
 - set -o pipefail
 - git submodule update --init --recursive

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "krzyzanowskim/CryptoSwift" ~> 0.2.2
+github "krzyzanowskim/CryptoSwift" ~> 0.3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "krzyzanowskim/CryptoSwift" "0.2.3"
+github "krzyzanowskim/CryptoSwift" "0.3.1"

--- a/JSONWebToken.podspec
+++ b/JSONWebToken.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = '10.9'
   spec.tvos.deployment_target = '9.0'
   spec.requires_arc = true
-  spec.dependency 'CryptoSwift', '~> 0.2.2'
+  spec.dependency 'CryptoSwift', '~> 0.3.1'
   spec.module_name = 'JWT'
 end


### PR DESCRIPTION
In Swift 2.2 there are many warnings because of CryptoSwift 0.2.2 dependency. Dependency has been updated to its 0.3.1 version.