### PR TITLE
SPM 3.0.2 compilation fixes: import Foundation, () for Void

### DIFF
--- a/Sources/ClaimSet.swift
+++ b/Sources/ClaimSet.swift
@@ -1,3 +1,6 @@
+
+import Foundation
+
 public struct ClaimSet {
   var claims: [String: Any]
 

--- a/Sources/Encode.swift
+++ b/Sources/Encode.swift
@@ -1,3 +1,6 @@
+
+import Foundation
+
 /*** Encode a set of claims
  - parameter claims: The set of claims
  - parameter algorithm: The algorithm to sign the payload with

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,7 +3,7 @@ import XCTest
 
 
 extension EncodeTests {
-  static var allTests: [(String, (EncodeTests) -> Void throws -> Void)] {
+  static var allTests: [(String, (EncodeTests) -> () throws -> ())] {
     return [
       ("testEncodingJWT", testEncodingJWT),
       ("testEncodingWithBuilder", testEncodingWithBuilder),
@@ -12,7 +12,7 @@ extension EncodeTests {
 }
 
 extension DecodeTests {
-  static var allTests: [(String, (DecodeTests) -> Void throws -> Void)] {
+  static var allTests: [(String, (DecodeTests) -> () throws -> ())] {
     return [
       ("testDecodingValidJWT", testDecodingValidJWT),
       ("testFailsToDecodeInvalidStringWithoutThreeSegments", testFailsToDecodeInvalidStringWithoutThreeSegments),
@@ -46,7 +46,7 @@ extension DecodeTests {
 }
 
 extension PayloadTests {
-  static var allTests: [(String, (PayloadTests) -> Void throws -> Void)] {
+  static var allTests: [(String, (PayloadTests) -> () throws -> ())] {
     return [
       ("testIssuer", testIssuer),
       ("testAudience", testAudience),


### PR DESCRIPTION
This PR addresses two issues I was seeing building with SPM & Swift 3.0.2. Issue #1 was macOS/Linux problem and #2 was Linux only.

1. The Data/time related components from Foundation were not being found unless Foundation was actually imported.
2. The LinuxTest function signatures needed to be either (Void) or (). I chose ()

All tests pass mac/Lin. Generated Xcode project still builds and tests pass.