### PR TITLE
Add missing Foundation imports

### DIFF
--- a/Sources/ClaimSet.swift
+++ b/Sources/ClaimSet.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct ClaimSet {
   var claims: [String: Any]
 

--- a/Sources/Encode.swift
+++ b/Sources/Encode.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /*** Encode a set of claims
  - parameter claims: The set of claims
  - parameter algorithm: The algorithm to sign the payload with


### PR DESCRIPTION
I was unable to build the project using `swift build` (both standalone and in a subproject) without these Foundation imports.