### PR TITLE
[WIP] Update to Swift 4 compatible commit of CryptoSwift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ xcuserdata/
 *.xccheckout
 .build/
 Packages/
+Carthage/Build

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "krzyzanowskim/CryptoSwift" ~> 0.6.1
+github "krzyzanowskim/CryptoSwift" "3a4dfda60001d1dcd1fd8feca9bc1d804284698c"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "krzyzanowskim/CryptoSwift" "0.6.1"
+github "krzyzanowskim/CryptoSwift" "3a4dfda60001d1dcd1fd8feca9bc1d804284698c"


### PR DESCRIPTION
I know it's time until a final Swift 4 release and CryptoSwift does not have a released version yet, so you probably might want to merge this into a separate branch if at all. In any case, here's how you could install this if this was merged into a branch named (say) "swift4":

```
github "kylef/JSONWebToken.swift" "swift4"
```

Until this PR is merged, you can install it via my fork like so:

```
github "Dschee/JSONWebToken.swift" "master"
```