### PR TITLE
Use CommonCrypto in JWT Pod

### DIFF
--- a/CommonCrypto/module.modulemap
+++ b/CommonCrypto/module.modulemap
@@ -1,0 +1,4 @@
+module CommonCrypto [system] {
+    header "shim.h"
+    export *
+}

--- a/CommonCrypto/shim.h
+++ b/CommonCrypto/shim.h
@@ -1,0 +1,1 @@
+#include <CommonCrypto/CommonCrypto.h>

--- a/JSONWebToken.podspec
+++ b/JSONWebToken.podspec
@@ -12,7 +12,18 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target = '9.0'
   spec.watchos.deployment_target = '2.0'
   spec.requires_arc = true
-  spec.dependency 'CryptoSwift', '~> 0.6.1'
   spec.module_name = 'JWT'
-  spec.exclude_files = ['Sources/HMACCommonCrypto.swift']
+  spec.exclude_files = ['Sources/HMACCryptoSwift.swift']
+
+  if ARGV.include?('lint')
+    spec.pod_target_xcconfig = {
+      'SWIFT_INCLUDE_PATHS' => Dir.pwd,
+    }
+  else
+    spec.pod_target_xcconfig = {
+      'SWIFT_INCLUDE_PATHS' => '$(PODS_ROOT)/JSONWebToken/',
+    }
+  end
+
+  spec.preserve_paths = 'CommonCrypto/{shim.h,module.modulemap}'
 end


### PR DESCRIPTION
This PR updates the pod spec to use CommonCrypto instead of CryptoSwift. Users of the library from CocoaPods can use the system CommonCrypto instead of the external dependency.