### PR TITLE
Make JWT Compile Again

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,17 @@
 import PackageDescription
 
 
-// #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-// let package = Package(
-//   name: "JWT",
-//   dependencies: [
-//     .Package(url: "https://github.com/kylef-archive/CommonCrypto.git", majorVersion: 1),
-//  ],
-//  exclude: [
-//    "Sources/JWT/HMACCryptoSwift.swift",
-//  ]
-// )
-//#else
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+let package = Package(
+   name: "JWT",
+   dependencies: [
+     .Package(url: "https://github.com/kylef-archive/CommonCrypto.git", majorVersion: 1),
+  ],
+  exclude: [
+    "Sources/JWT/HMACCryptoSwift.swift",
+  ]
+)
+#else
 let package = Package(
   name: "JWT",
   dependencies: [
@@ -21,4 +21,4 @@ let package = Package(
     "Sources/JWT/HMACCommonCrypto.swift",
   ]
 )
-//#endif
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,9 @@ import PackageDescription
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 let package = Package(
-   name: "JWT",
-   dependencies: [
-     .Package(url: "https://github.com/kylef-archive/CommonCrypto.git", majorVersion: 1),
+  name: "JWT",
+  dependencies: [
+    .Package(url: "https://github.com/kylef-archive/CommonCrypto.git", majorVersion: 1),
   ],
   exclude: [
     "Sources/JWT/HMACCryptoSwift.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -1,24 +1,24 @@
 import PackageDescription
 
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+// #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+// let package = Package(
+//   name: "JWT",
+//   dependencies: [
+//     .Package(url: "https://github.com/kylef-archive/CommonCrypto.git", majorVersion: 1),
+//  ],
+//  exclude: [
+//    "Sources/JWT/HMACCryptoSwift.swift",
+//  ]
+// )
+//#else
 let package = Package(
   name: "JWT",
   dependencies: [
-    .Package(url: "https://github.com/kylef-archive/CommonCrypto.git", majorVersion: 1),
-  ],
-  exclude: [
-    "Sources/JWT/HMACCryptoSwift.swift",
-  ]
-)
-#else
-let package = Package(
-  name: "JWT",
-  dependencies: [
-    .Package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", majorVersion: 0, minor: 6),
+    .Package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", majorVersion: 0, minor: 8),
   ],
   exclude: [
     "Sources/JWT/HMACCommonCrypto.swift",
   ]
 )
-#endif
+//#endif

--- a/Sources/JWT/CompactJSONEncoder.swift
+++ b/Sources/JWT/CompactJSONEncoder.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 class CompactJSONEncoder: JSONEncoder {
   override func encode<T : Encodable>(_ value: T) throws -> Data {
     return try encodeString(value).data(using: .ascii) ?? Data()


### PR DESCRIPTION
This pull request:
* fixes an issue where Foundation was not imported in CompactJSONEncoder.swift,
* bumps the CryptoSwift version to 0.8.0 for Swift 4 (somewhat duplicates #84), and most importantly,
* compiles on both Apple platforms and Linux (I tried on both!)