### PR TITLE
make "claims" of "ClaimSet" readable

### DIFF
--- a/Sources/JWT/ClaimSet.swift
+++ b/Sources/JWT/ClaimSet.swift
@@ -15,7 +15,7 @@ func parseTimeInterval(_ value: Any?) -> Date? {
 }
 
 public struct ClaimSet {
-  public private (set) var claims: [String: Any]
+  public internal (set) var claims: [String: Any]
 
   public init(claims: [String: Any]? = nil) {
     self.claims = claims ?? [:]

--- a/Sources/JWT/ClaimSet.swift
+++ b/Sources/JWT/ClaimSet.swift
@@ -15,7 +15,7 @@ func parseTimeInterval(_ value: Any?) -> Date? {
 }
 
 public struct ClaimSet {
-  var claims: [String: Any]
+  public private (set) var claims: [String: Any]
 
   public init(claims: [String: Any]? = nil) {
     self.claims = claims ?? [:]


### PR DESCRIPTION
As discussed in https://github.com/kylef/JSONWebToken.swift/issues/69 in some cases
access to the raw json data is needed. Therefore „claims“ should be
exposed.
