### PR TITLE
Update version of CryptoSwift dependency in SPM package definition

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 let package = Package(
   name: "JWT",
   dependencies: [
-    .Package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", majorVersion: 0, minor: 6),
+    .Package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", majorVersion: 0, minor: 8),
   ],
   exclude: [
     "Sources/JWT/HMACCommonCrypto.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,7 @@
 import PackageDescription
 
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-let package = Package(
-  name: "JWT",
-  dependencies: [
-    .Package(url: "https://github.com/kylef-archive/CommonCrypto.git", majorVersion: 1),
-  ],
-  exclude: [
-    "Sources/JWT/HMACCryptoSwift.swift",
-  ]
-)
-#else
+
 let package = Package(
   name: "JWT",
   dependencies: [
@@ -21,4 +11,4 @@ let package = Package(
     "Sources/JWT/HMACCommonCrypto.swift",
   ]
 )
-#endif
+

--- a/Sources/JWT/CompactJSONEncoder.swift
+++ b/Sources/JWT/CompactJSONEncoder.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 class CompactJSONEncoder: JSONEncoder {
   override func encode<T : Encodable>(_ value: T) throws -> Data {
     return try encodeString(value).data(using: .ascii) ?? Data()


### PR DESCRIPTION
I was unable to compile JSONWebToken with Swift 4 on Linux because the CryptoSwift dependency had errors thrown during compilation.
It turned out that those errors do not occur in newer versions of CryptoSwift.