### PR TITLE
Expose ClaimSet.claims publicly

### DIFF
--- a/Sources/JWT/ClaimSet.swift
+++ b/Sources/JWT/ClaimSet.swift
@@ -15,7 +15,7 @@ func parseTimeInterval(_ value: Any?) -> Date? {
 }
 
 public struct ClaimSet {
-  var claims: [String: Any]
+  public var claims: [String: Any]
 
   public init(claims: [String: Any]? = nil) {
     self.claims = claims ?? [:]


### PR DESCRIPTION
It seems like this should be exposed as `public`. Especially since `subscript` is also public, unless I'm missing something, I'm not sure the value of keeping this private.