### PR TITLE
Update swift version to 5.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.4.0
 
 import PackageDescription
 

--- a/Sources/JWA/JWA.swift
+++ b/Sources/JWA/JWA.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a JSON Web Algorithm (JWA)
 /// https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
-public protocol Algorithm: class {
+public protocol Algorithm: AnyObject {
   var name: String { get }
 }
 


### PR DESCRIPTION
This also solve issue when installing with SPM on latest release.

Error log:
```
the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version:5.4.0' to specify the current Swift toolchain version as the lowest Swift version supported by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it
```

Info:
- Using Xcode 12.5